### PR TITLE
Add Unix specific Modding API

### DIFF
--- a/ModInstaller/ModManager.cs
+++ b/ModInstaller/ModManager.cs
@@ -314,7 +314,7 @@ namespace ModInstaller
                 {
                     case "Modding API":
                         _apiLink = OS == "Windows" ? mod.Element("Link")?.Value : mod.Element("UnixLink")?.Value;
-                        _apiSha1 = mod.Element("Files")?.Element("File")?.Element("SHA1")?.Value;
+                        _apiSha1 = OS == "Windows" ? mod.Element("Files")?.Element("File")?.Element("SHA1")?.Value : mod.Element("Files")?.Element("File")?.Element("UnixSHA1")?.Value;
                         _currentPatch = mod.Element("Files")?.Element("File")?.Element("Patch")?.Value;
                         break;
                     default:

--- a/modlinks.xml
+++ b/modlinks.xml
@@ -29,11 +29,12 @@
 				<File>
 					<Name>Assembly-CSharp.dll</Name>
 					<SHA1>E880EA1B2B4B57FBD6ECA36B26746F08FF4EEF9F</SHA1>
+					<UnixSHA1>E5BFD2C3BD46B98492FE9FCEB2D5DD9B04E2043B</UnixSHA1>
 					<Patch>1.4.3.2</Patch>
 				</File>
 			</Files>
 			<Link><![CDATA[https://drive.google.com/uc?export=download&id=1lMvPf30KGvHKcOW-q0-tQnJ_zyljmyex]]></Link>
-			<UnixLink><![CDATA[https://drive.google.com/uc?export=download&id=1lMvPf30KGvHKcOW-q0-tQnJ_zyljmyex]]></UnixLink>
+			<UnixLink><![CDATA[https://github.com/hk-modding/api/releases/download/1.4.3.2-60/Unix.zip]]></UnixLink>
 			<Dependencies />
 		</ModLink>
 		<ModLink>


### PR DESCRIPTION
Should solve issue #93. A corresponding change to ModInstaller2 needs to be made to incorporate the UnixSHA1 otherwise the hash check will fail on ModInstaller2 for Unix only.